### PR TITLE
bugfix for tar failure according to the source file compression format

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
+# 주의사항
+vagrant up 실행 후에 ambari UI에서 HAWQ를 제외하고 hadoop을 설치하십시오.
+그리고 vm의 sysctl 설정을 변경한 후 HAWQ를 마져 설치하십시오.
+
 # Vagrant PHD 3.0
 
 Vagrant based Pivotal HD 3.0 cluster setup. The vagrant file and helper scripts sets up a 2 node cluster and an ambari host with all the required steps as mentioned in the Pivotal HD installation guide. By default it provisions a PHD cluster with HDFS, YARN, HAWQ, Nagios, and Ganglia components. You can add/modify the placement of the component using the clusterblueprint.json, and clustertemplate.json files. The project is inspired by an existing [Vagrant PHD] (https://github.com/tzolov/vagrant-pivotalhd) project created by Christian Tzolov from Pivotal.

--- a/ambari_install.sh
+++ b/ambari_install.sh
@@ -21,8 +21,12 @@ chmod a+rx /staging
 
 for var in "$@" 
 do
-
-tar -xzf /vagrant/$var -C /staging/
+ if [[ "$var" == *.gz ]]
+ then
+   tar -xzf /vagrant/$var -C /staging/
+ else
+   tar -xf /vagrant/$var -C /staging/
+ fi
 
 #filename=$(basename "$var")
 #filename="${filename%.*}"


### PR DESCRIPTION
Hi, when i run 'vagrant up', it fails with following error. this is the fix for it.

```
gzip: stdin: not in gzip format
tar: Child returned status 1
tar: Error is not recoverable: exiting now
```

becase, on virtual box vm, "tar zxf" command fails with *.tar input file which is defined in "Vagrantfile" as following:

```
PHD_30 = ["AMBARI-1.7.1-87-centos6.tar", "PHD-3.0.0.0-249-centos6.tar", "PADS-1.3.0.0-12954.tar", "PHD-UTILS-1.1.0.20-centos6.tar", HAWQ_ORIGINAL_AMBARI_PLUGIN]
```
